### PR TITLE
Support the data format used by polar, pie, and donut charts

### DIFF
--- a/app/components/ember-chart.js
+++ b/app/components/ember-chart.js
@@ -12,7 +12,7 @@ export default Ember.Component.extend({
     var options = Ember.merge({}, this.get('options'));
 
     var chart = new Chart(context)[type](data, options);
-    
+
     if (this.get('legend')) {
       var legend = chart.generateLegend();
       this.$().parent().append(legend);
@@ -25,35 +25,61 @@ export default Ember.Component.extend({
     if (this.get('legend')) {
       this.$().parent().children('[class$=legend]').remove();
     };
-    
+
     this.get('chart').destroy();
   }.on('willDestroyElement'),
 
   updateChart: function(){
     try {
-      var self = this;
-      this.get('data.datasets').forEach(function(dataset, i) {
-      	dataset.data.forEach(function(item, j) {
-	  var chart = self.get('chart');
-	  		
-	  if(typeof chart.datasets[i] === 'undefined') {
-	    self.get('chart').segments[j].value = item;
-	  } else {
-	    var dataSet = self.get('chart').datasets[i];
-	  
-	    if(typeof dataSet.bars !== 'undefined') {
-	      self.get('chart').datasets[i].bars[j].value = item;
-	    } else {
-	      self.get('chart').datasets[i].points[j].value = item;
-	    }
-	  }
-	});
-      });
-      this.get('chart').update();
+      var chart = this.get('chart');
+      var data = this.get('data');
+      var needUpdate = false;
+      // Line, Bar and Radar charts
+      if (data.datasets) {
+        data.datasets.forEach(function(dataset, i) {
+          dataset.data.forEach(function(item, j) {
+            if (typeof chart.datasets[i] === 'undefined') {
+              chart.segments[j].value = item;
+            } else {
+              var dataSet = chart.datasets[i];
+
+              if(typeof dataSet.bars !== 'undefined') {
+                chart.datasets[i].bars[j].value = item;
+              } else {
+                chart.datasets[i].points[j].value = item;
+              }
+            }
+          });
+        });
+        needUpdate = true;
+      }
+      else {
+        // Polar, Pie and Doughnut charts use an array as their data source
+        if (Array.isArray(data)) {
+          data.forEach(function(segment, i) {
+            if (typeof chart.segments[i] !== 'undefined') {
+              if (chart.segments[i].value != segment.value) {
+                chart.segments[i].value = segment.value;
+                needUpdate = true;
+              }
+            }
+            else {
+              // there are now more segments than the chart knows about; add them
+              chart.addData(segment, i, true);
+              needUpdate = true;
+            }
+          });
+        }
+      }
+
+      // only update if the data has changed
+      if (needUpdate) {
+        chart.update();
+      }
     } catch(error) {
       Ember.warn('Dataset is not equal in structure as previous values. Rebuilding chart...');
       this.destroyChart();
       this.renderChart();
     }
-  }.observes('data', 'options')
+  }.observes('data', 'data.[]', 'options')
 });


### PR DESCRIPTION
Polar, pie, and donut charts use an array as their data source, rather than an object containing data sets. Support this by listening to array changes as well as handling the different data format.

Additionally, new segments will be added as needed when the data is updated.