### PR TITLE
Pie chart does not update well for dynamic segments

### DIFF
--- a/addon/chart-data-updater.js
+++ b/addon/chart-data-updater.js
@@ -39,7 +39,7 @@ export default Ember.Object.extend({
 
     data.forEach(function(segment) {
       var currentSegment = chart.segments.findBy('label', segment.label);
-      if(chart.segments.findBy('label', segment.label)) {
+      if(currentSegment) {
         segment.value = segment.value || 0;
         if (currentSegment.value !== segment.value) {
           currentSegment.value = segment.value;

--- a/addon/chart-data-updater.js
+++ b/addon/chart-data-updater.js
@@ -37,20 +37,36 @@ export default Ember.Object.extend({
     var chart = this.get('chart');
     var needUpdate = false;
 
-    data.forEach(function(segment, i) {
-      if (typeof chart.segments[i] !== 'undefined') {
+    data.forEach(function(segment) {
+      var currentSegment = chart.segments.findBy('label', segment.label);
+      if(chart.segments.findBy('label', segment.label)) {
         segment.value = segment.value || 0;
-        if (chart.segments[i].value !== segment.value) {
-          chart.segments[i].value = segment.value;
+        if (currentSegment.value !== segment.value) {
+          currentSegment.value = segment.value;
           needUpdate = true;
         }
       }
       else {
-        // there are now more segments than the chart knows about; add them
+        // given data segment does not yet exist; add them
         chart.addData(segment, i, true);
         needUpdate = true;
       }
     });
+    
+  //remove segments no longer used
+	if(chart.segments.length !== data.length) {
+		var dataSegmentsLabels = data.mapBy('label');
+		
+		for(var i = 0; i < chart.segments.length; i++) {
+		  var currentSegment = chart.segments[i];
+		  if(!dataSegmentsLabels.contains(currentSegment.label)) {
+		    chart.segments.removeObject(currentSegment);
+			needUpdate = true;
+			i--;
+		  }
+		}
+	}
+    
     return needUpdate;
   }
 });

--- a/addon/chart-data-updater.js
+++ b/addon/chart-data-updater.js
@@ -48,7 +48,7 @@ export default Ember.Object.extend({
       }
       else {
         // given data segment does not yet exist; add them
-        chart.addData(segment, i, true);
+        chart.addData(segment, chart.segments.length, true);
         needUpdate = true;
       }
     });


### PR DESCRIPTION
If the segments did change, the `updatePieCharts` function featured several bugs:

* As data segments does not necessarily has the same format as the chart segments, the script could update a wrong segment.
* If your data set would have lower segments than your chart.segments, the old segments were not removed.

---
Example (simplified data):

Imagine an pie chart with a following set:
[ jpg: 2, gif: 4, docx: 54 ]

Now we update this pie chart with following set:
[ gif: 42, docx: 14, rar: 3 ]

Note the following: `gif` and `docx` segments are placed at an other index, because the `jpg` segment has been deleted.

In the old situation:
* `jpg` would have been updated to 42, instead of being removed.
* `gif` would have been updated to 14
* `docx` would have been updated to 3
* `rar` would have been added with 3